### PR TITLE
management of remove config sign from .htaccess nextcloud

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
@@ -35,9 +35,13 @@ else
     if [ -f /usr/share/nextcloud/.htaccess.rpmsave ]; then
         rm -f /usr/share/nextcloud/.htaccess.rpmsave
     fi
+    if [ -f /usr/share/nextcloud/.htaccess.rpmnew ]; then
+        rm -f /usr/share/nextcloud/.htaccess.rpmnew
+    fi
     OCC "maintenance:mode --on"
     OCC "upgrade"
     OCC "maintenance:mode --off"
+    OCC "integrity:check-core"
     # Catch 'Nextcloud is already latest version' message
     if [ $? -eq 3 ]; then
         exit 0


### PR DESCRIPTION
`.htaccess` of ["nextcloud" rpm](https://github.com/nextcloud/server-packages) signed as config file cause a problem.

**How to riproduce**
1. install nextcloud 11.0.3
2. update to 12.0.4
3. `/usr/share/nextcloud/.htaccess.rpmnew` has been created
4. nextcloud admin page shows a warning message of integrity check and a security warning

![nextcloud](https://user-images.githubusercontent.com/1625334/34784785-8efa2d58-f62f-11e7-99e1-fde825c5bfca.PNG)

**Expected behavior**
The update ends and no security warning appears.

**Solution proposal**
This PR remove .rpmnew and .rpmsave files after update and launch an "occ integrity:check-core" command to fix the problem for the update scenario.
I've tested the following cases:
1. update from 12.0.4 (previously update from 11.0.3)
2. update from 11.0.3
3. clean installation

Note: this PR is linked with this other [nextcloud PR](https://github.com/nextcloud/server-packages/pull/16).