### PR TITLE
Use cron for background tasks

### DIFF
--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -1,7 +1,7 @@
 Summary: NethServer Nextcloud configuration
 Name: nethserver-nextcloud
 Version: 1.2.6
-Release: 2%{?dist}
+Release: 1%{?dist}
 License: GPL
 Source: %{name}-%{version}.tar.gz
 BuildArch: noarch
@@ -44,9 +44,6 @@ mkdir -p %{buildroot}/var/lib/nethserver/nextcloud
 
 
 %changelog
-* Wed Oct 10 2018 Dan Brown <dan@familybrown.org> - 1.2.6-2
-- Run background tasks via cron job rather than AJAX
-
 * Wed Sep 26 2018 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.2.6-1
 - Nextcloud: upgrade to 14.0.1 - nethserver/dev#5588
 

--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -1,7 +1,7 @@
 Summary: NethServer Nextcloud configuration
 Name: nethserver-nextcloud
 Version: 1.2.6
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPL
 Source: %{name}-%{version}.tar.gz
 BuildArch: noarch
@@ -44,6 +44,9 @@ mkdir -p %{buildroot}/var/lib/nethserver/nextcloud
 
 
 %changelog
+* Wed Oct 10 2018 Dan Brown <dan@familybrown.org> - 1.2.6-2
+- Run background tasks via cron job rather than AJAX
+
 * Wed Sep 26 2018 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.2.6-1
 - Nextcloud: upgrade to 14.0.1 - nethserver/dev#5588
 

--- a/root/etc/cron.d/nextcloud
+++ b/root/etc/cron.d/nextcloud
@@ -1,1 +1,1 @@
-*/15 * * * *   apache /opt/rh/rh-php71/root/usr/bin/php -f /usr/share/nextcloud/cron.php
+*/15 * * * *   apache /usr/bin/scl enable rh-php71 -- php -f /usr/share/nextcloud/cron.php

--- a/root/etc/cron.d/nextcloud
+++ b/root/etc/cron.d/nextcloud
@@ -1,1 +1,1 @@
-*/15 * * * *  /opt/rh/rh-php71/root/usr/bin/php -f /usr/share/nextcloud/cron.php
+*/15 * * * *   apache /opt/rh/rh-php71/root/usr/bin/php -f /usr/share/nextcloud/cron.php

--- a/root/etc/cron.d/nextcloud
+++ b/root/etc/cron.d/nextcloud
@@ -1,0 +1,1 @@
+*/15 * * * *  /opt/rh/rh-php71/root/usr/bin/php -f /usr/share/nextcloud/cron.php

--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
@@ -28,6 +28,7 @@ OCC "config:system:set mail_from_address --value=no-reply";
 OCC "config:system:set mail_domain --value=".$cdb->get_value('DomainName');
 OCC "config:system:set mail_smtphost --value=localhost";
 OCC "config:system:set mail_smtpport --value=25";
+OCC "background:cron";
 
 my $i = 2;
 foreach ($ndb->green(), $ndb->red(), $ndb->orange(), $ndb->blue()) {


### PR DESCRIPTION
Nextcloud defaults to using AJAX to run background tasks.  However, its documentation recommends configuring a cron job instead.  This PR adds a task at /etc/cron.d/nextcloud to run the tasks every 15 minutes, and configures Nextcloud to use that task.