### PR TITLE
Delete trusted_domains with occ

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
@@ -17,6 +17,7 @@ my $ndb = esmith::NetworksDB->open_ro();
 my $cdb = esmith::ConfigDB->open_ro();
 
 my $fqdn = join('.', $cdb->get_value('SystemName'), $cdb->get_value('DomainName'));
+OCC "config:system:delete trusted_domains";
 OCC "config:system:set trusted_domains 0 --value=localhost";
 OCC "config:system:set trusted_domains 1 --value=$fqdn";
 OCC "config:system:set memcache.local --value='\\OC\\Memcache\\APCu'";


### PR DESCRIPTION
NethServer/dev#6067

To respect deletions in GUI trusted_domains are deleted with occ before the trusted domains are added in the nethserver-nextcloud-occ-conf action.
