### PR TITLE
Use rh-php73 for nextcloud vhost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,16 +62,16 @@ The database is automatically saved by ``nethserver-mysql``.
 OCC
 ===
 
-When using ``occ`` command, PHP 7.2 should be enabled inside the environment.
+When using ``occ`` command, PHP 7.3 should be enabled inside the environment.
 
 Invocation example: ::
 
-  su - apache -s /bin/bash -c "source /opt/rh/rh-php72/enable; cd /usr/share/nextcloud/; php occ ldap:show-config"
+  su - apache -s /bin/bash -c "source /opt/rh/rh-php73/enable; cd /usr/share/nextcloud/; php occ ldap:show-config"
 
-Log of rh-php72-fpm
+Log of rh-php73-fpm
 ===================
 
-The log of rh-php72-fpm can be found at `/var/opt/rh/rh-php72/log/php-fpm/error-nextcloud.log`
+The log of rh-php73-fpm can be found at `/var/opt/rh/rh-php73/log/php-fpm/error-nextcloud.log`
 
 Cockpit API
 ===========

--- a/api/read
+++ b/api/read
@@ -49,15 +49,15 @@ if ($action eq 'app-info') {
 } elsif ($action eq 'configuration') {
 
     # get stats
-    my $version = `su - apache -s /bin/bash -c "source /opt/rh/rh-php72/enable; cd /usr/share/nextcloud/; php occ status" 2>/dev/null | grep version: | awk '{print \$3}'`;
+    my $version = `su - apache -s /bin/bash -c "source /opt/rh/rh-php73/enable; cd /usr/share/nextcloud/; php occ status" 2>/dev/null | grep version: | awk '{print \$3}'`;
     chomp($version);
-    my $users = `su - apache -s /bin/bash -c "source /opt/rh/rh-php72/enable; cd /usr/share/nextcloud/; php occ user:list" 2>/dev/null | wc -l`;
+    my $users = `su - apache -s /bin/bash -c "source /opt/rh/rh-php73/enable; cd /usr/share/nextcloud/; php occ user:list" 2>/dev/null | wc -l`;
     chomp($users);
 
     # read pass and check if is changed
     my $hashPass = `mysql nextcloud -B -N -e "select password from oc_users where uid='admin'" | cut -d'|' -f 2`;
     chomp($hashPass);
-    my $adminPassWarn = `source /opt/rh/rh-php72/enable; php /usr/libexec/nethserver/api/nethserver-nextcloud/admin-password-helper '$hashPass'`;
+    my $adminPassWarn = `source /opt/rh/rh-php73/enable; php /usr/libexec/nethserver/api/nethserver-nextcloud/admin-password-helper '$hashPass'`;
 
     # build the output
     $output->{'stats'} = {

--- a/createlinks
+++ b/createlinks
@@ -39,7 +39,7 @@ event_templates("nethserver-nextcloud-update", qw(
 
 event_services("nethserver-nextcloud-update", qw(
   httpd restart
-  rh-php72-php-fpm restart
+  rh-php73-php-fpm restart
 ));
 
 event_templates("nethserver-nextcloud-save", qw(

--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -18,26 +18,26 @@ Provides: nextcloud
 Obsoletes: nextcloud
 Requires: nethserver-httpd
 Requires: nethserver-mysql
-Requires: nethserver-rh-php72-php-fpm >= 1.1.0
+Requires: nethserver-rh-php73-php-fpm >= 1.0.0
 Requires: samba-client
 
 # Required php packages
-Requires: rh-php72
-Requires: rh-php72-php-fpm
-Requires: rh-php72-php-gd
-Requires: rh-php72-php-pdo
-Requires: rh-php72-php-mbstring
-Requires: rh-php72-php-imagick
+Requires: rh-php73
+Requires: rh-php73-php-fpm
+Requires: rh-php73-php-gd
+Requires: rh-php73-php-pdo
+Requires: rh-php73-php-mbstring
+Requires: rh-php73-php-imagick
 
 # Recommended php packages
-Requires: rh-php72-php-intl
+Requires: rh-php73-php-intl
 
 # Required php packages for specific apps
-Requires: rh-php72-php-ldap
-Requires: sclo-php72-php-smbclient
+Requires: rh-php73-php-ldap
+Requires: sclo-php73-php-smbclient
 
 # Required php packages for MariaDB
-Requires: rh-php72-php-pdo_mysql
+Requires: rh-php73-php-pdo_mysql
 
 %description
 NethServer Nextcloud files and configuration.
@@ -77,7 +77,7 @@ cp -a api/* %{buildroot}/usr/libexec/nethserver/api/%{name}/
 %doc COPYING
 %dir %{_nseventsdir}/%{name}-update
 %config %attr (0440,root,root) %{_sysconfdir}/sudoers.d/90_nethserver_nextcloud
-%config(noreplace) %{_sysconfdir}/opt/rh/rh-php72/php-fpm.d/000-nextcloud.conf
+%config(noreplace) %{_sysconfdir}/opt/rh/rh-php73/php-fpm.d/000-nextcloud.conf
 %config(noreplace) %attr(0644,apache,apache) /usr/share/nextcloud/.user.ini
 %dir %attr(0755,root,apache) /usr/share/nextcloud
 %attr(-,apache,apache) /usr/share/nextcloud
@@ -242,4 +242,3 @@ cp -a api/* %{buildroot}/usr/libexec/nethserver/api/%{name}/
 
 * Mon Aug 01 2016 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.0.0-1
 - First Nextcloud release - NethServer/dev#5055
-

--- a/root/etc/cron.d/nextcloud
+++ b/root/etc/cron.d/nextcloud
@@ -1,1 +1,1 @@
-*/5 * * * *   apache /usr/bin/scl enable rh-php72 -- php -f /usr/share/nextcloud/cron.php
+*/5 * * * *   apache /usr/bin/scl enable rh-php73 -- php -f /usr/share/nextcloud/cron.php

--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
@@ -3,7 +3,7 @@
 function OCC
 {
     params=$@;
-    source /opt/rh/rh-php72/enable
+    source /opt/rh/rh-php73/enable
     cd /usr/share/nextcloud/
     TERM=dumb runuser -s /bin/bash apache -c "php -dmemory_limit=512M ./occ $params"
 }

--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
@@ -8,7 +8,7 @@ use esmith::ConfigDB;
 sub OCC
 {
     my $params = join(" ", @_);
-    system("TERM=dumb su - apache -s /bin/bash -c \"source /opt/rh/rh-php72/enable; cd /usr/share/nextcloud/; php -dmemory_limit=512M occ $params\"");
+    system("TERM=dumb su - apache -s /bin/bash -c \"source /opt/rh/rh-php73/enable; cd /usr/share/nextcloud/; php -dmemory_limit=512M occ $params\"");
 }
 
 # Update trusted domains

--- a/root/etc/e-smith/templates/etc/httpd/conf.d/zz_nextcloud.conf/10base
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/zz_nextcloud.conf/10base
@@ -17,7 +17,7 @@
     </IfModule>
 
     <FilesMatch \.php$>
-      SetHandler "proxy:unix:/var/run/rh-php72-php-fpm/nethserver-nextcloud-php72.sock|fcgi://localhost/"
+      SetHandler "proxy:unix:/var/run/rh-php73-php-fpm/nethserver-nextcloud-php73.sock|fcgi://localhost/"
     </FilesMatch>
 
     SetEnv HOME /usr/share/nextcloud

--- a/root/etc/opt/rh/rh-php73/php-fpm.d/000-nextcloud.conf
+++ b/root/etc/opt/rh/rh-php73/php-fpm.d/000-nextcloud.conf
@@ -3,10 +3,10 @@
 ;
 
 [nethserver-nextcloud]
-listen = /var/run/rh-php72-php-fpm/nethserver-nextcloud-php72.sock
+listen = /var/run/rh-php73-php-fpm/nethserver-nextcloud-php73.sock
 
 ;Logs
-php_admin_value[error_log] = /var/opt/rh/rh-php72/log/php-fpm/error-nextcloud.log
+php_admin_value[error_log] = /var/opt/rh/rh-php73/log/php-fpm/error-nextcloud.log
 php_admin_flag[log_errors] = on
 
 pm = dynamic
@@ -23,11 +23,11 @@ listen.mode = 0660
 
 ; Set data paths to directories owned by process user
 php_value[session.save_handler] = files
-php_value[session.save_path]    = /var/opt/rh/rh-php72/lib/php/session
-php_value[soap.wsdl_cache_dir]  = /var/opt/rh/rh-php72/lib/php/wsdlcache
+php_value[session.save_path]    = /var/opt/rh/rh-php73/lib/php/session
+php_value[soap.wsdl_cache_dir]  = /var/opt/rh/rh-php73/lib/php/wsdlcache
 
 ; Set opcache settings 
-php_value[opcache.file_cache]  = /var/opt/rh/rh-php72/lib/php/opcache
+php_value[opcache.file_cache]  = /var/opt/rh/rh-php73/lib/php/opcache
 php_value[opcache.enable_cli]  = 1
 php_value[opcache.interned_strings_buffer]  = 8
 php_value[opcache.max_accelerated_files]  = 10000


### PR DESCRIPTION
https://community.nethserver.org/t/nextcloud-passwords-php-7-2-24-is-no-longer-supported-please-check-the-system-requirements/14883

PHP 7.3 is recommended https://docs.nextcloud.com/server/18/admin_manual/installation/system_requirements.html

We still have time to switch to PHP 7.3 until Nov 2020: https://access.redhat.com/support/policy/updates/rhscl-rhel7

Passwords, which is not an official plugin, but a very popular one, requires indeed 7.3 (with a lot of libraries): https://git.mdns.eu/nextcloud/passwords/wikis/Administrators/System-Requirements

NethServer/dev#6120