### PR TITLE
Fix missing primary keys and optional columns

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-conf
@@ -102,6 +102,8 @@ if [[ -n $database ]]; then
         #Enabling MySQL 4-byte support
         OCC "config:system:set mysql.utf8mb4 --type boolean --value='true'"
         OCC "maintenance:repair"
+        OCC "db:add-missing-primary-keys"
+        OCC "db:add-missing-columns"
         # Enable back accessibility
         OCC "app:enable accessibility"
     fi


### PR DESCRIPTION
After the migration we have some fix to do to the database

```
The database is missing some primary keys. Due to the fact that adding primary keys on big tables could take some time they were not added automatically. 
By running "occ db:add-missing-primary-keys" those missing primary keys could be added manually while the instance keeps running.
Missing primary key on table "oc_federated_reshares".
Missing primary key on table "oc_systemtag_object_mapping".
Missing primary key on table "oc_comments_read_markers".
Missing primary key on table "oc_collres_resources".
Missing primary key on table "oc_collres_accesscache".
Missing primary key on table "oc_filecache_extended".

The database is missing some optional columns. Due to the fact that adding columns on big tables could take some time they were not added automatically when they can be optional. 
By running "occ db:add-missing-columns" those missing columns could be added manually while the instance keeps running. Once the columns are added some features might improve responsiveness or usability.
Missing optional column "reference_id" in table "oc_comments".
```

relative to this https://github.com/NethServer/dev/issues/6506#issuecomment-858742401