### PR TITLE
Enable APC in cron job

### DIFF
--- a/root/etc/cron.d/nextcloud
+++ b/root/etc/cron.d/nextcloud
@@ -1,1 +1,1 @@
-*/5 * * * *   apache /usr/bin/scl enable rh-php73 -- php -d memory_limit=512M -f /usr/share/nextcloud/cron.php
+*/5 * * * *   apache /usr/bin/scl enable rh-php73 -- php -d memory_limit=512M -d apc.enable_cli=1 -f /usr/share/nextcloud/cron.php


### PR DESCRIPTION
Nextcloud docs recommend enabling APC for the periodic cron job to avoid out of memory errors.  See https://community.nethserver.org/t/nextcloud-cron-issue/18495/2?u=danb35