### PR TITLE
occ: add apc.enable_cli

### DIFF
--- a/root/usr/local/sbin/occ
+++ b/root/usr/local/sbin/occ
@@ -22,4 +22,4 @@
 
 # OCC wrapper running PHP from SCL
 
-runuser -u apache -- scl enable rh-php73 --  php -d memory_limit=1024M  /usr/share/nextcloud/occ "$@"
+runuser -u apache -- scl enable rh-php73 --  php -d memory_limit=1024M -d apc.enable_cli=1 /usr/share/nextcloud/occ "$@"


### PR DESCRIPTION
Prevent upstream bug:

 Allowed memory size of xxx bytes exhausted

NethServer/dev#6539