### PR TITLE
Go to 22.2.0

### DIFF
--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -6,7 +6,7 @@ License: GPL
 Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.tar.gz
 
-%define nc_version 22.1.1
+%define nc_version 22.2.0
 Source2: https://download.nextcloud.com/server/releases/nextcloud-%{nc_version}.tar.bz2
 
 BuildArch: noarch


### PR DESCRIPTION
Update to 22.2.0

The main goal is to remove the warning about libsodium (it needs php >= 7.4)

https://github.com/NethServer/dev/issues/6576