### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,8 +149,8 @@ Full reinstall
 As with many other applications in NethServer, un-installing the Nextcloud application **does not** remove the settings, stored files, or the database. Here are the suggested steps to do a full un-install and re-install with a fresh configuration:
 
 1. Uninstall Nextcloud using the admin page
-2. Remove the packages: ``yum remove nethserver-nextcloud nextcloud``
-3. Drop the MySQL database: ``/opt/rh/rh-mariadb105/root/bin/mysql --socket="/var/run/rh-mariadb105-mariadb/nextcloud-mysql.sock" -e "drop database nextcloud;"``
+2. Drop the MySQL database: ``/opt/rh/rh-mariadb105/root/bin/mysql --socket="/var/run/rh-mariadb105-mariadb/nextcloud-mysql.sock" -e "drop database nextcloud;"``
+3. Remove the packages: ``yum remove nethserver-nextcloud``
 4. Remove the whole Nextcloud directory: ``rm -rf /usr/share/nextcloud/``
 5. Remove the e-smith DB configuration: ``config delete nextcloud``
 6. Remove the NethServer config directory (WARNING: will remove user data): ``rm -rf /var/lib/nethserver/nextcloud``


### PR DESCRIPTION
- The Full reinstall didn't work because the DB could not be dropped because the socket doesn't exist anymore because of previous uninstall of Nextcloud
- nextcloud.rpm isn't used anymore

See also:

https://community.nethserver.org/t/full-reinstall-of-nextcloud/19660/4?u=mrmarkuz