### PR TITLE
Increase opcache limit

### DIFF
--- a/root/etc/opt/rh/rh-php73/php-fpm.d/000-nextcloud.conf
+++ b/root/etc/opt/rh/rh-php73/php-fpm.d/000-nextcloud.conf
@@ -29,9 +29,9 @@ php_value[soap.wsdl_cache_dir]  = /var/opt/rh/rh-php73/lib/php/wsdlcache
 ; Set opcache settings 
 php_value[opcache.file_cache]  = /var/opt/rh/rh-php73/lib/php/opcache
 php_value[opcache.enable_cli]  = 1
-php_value[opcache.interned_strings_buffer]  = 8
-php_value[opcache.max_accelerated_files]  = 10000
-php_value[opcache.memory_consumption]  = 128
+php_value[opcache.interned_strings_buffer]  = 32
+php_value[opcache.max_accelerated_files]  = 50000
+php_value[opcache.memory_consumption]  = 256
 php_value[opcache.save_comments]  = 1
 php_value[opcache.revalidate_freq]  = 1
 


### PR DESCRIPTION
See https://community.nethserver.org/t/nextcloud-the-php-opcache-module-is-not-properly-configured/19732

Nextcloud reclaims more memory and file keys storage

max_accelerated_files : 100 000 is the maximum value
opcache.memory_consumption : set to 256  I understand it must be < php_admin_value[memory_limit] = 512M
opcache.interned_strings_buffer: default is 8 increased to 32 (could be 64)
