### PR TITLE
Display versionstring in the dashboard

### DIFF
--- a/api/read
+++ b/api/read
@@ -49,7 +49,7 @@ if ($action eq 'app-info') {
 } elsif ($action eq 'configuration') {
 
     # get stats
-    my $version = `/usr/local/sbin/occ status 2>/dev/null | grep version: | awk '{print \$3}'`;
+    my $version = `/usr/local/sbin/occ status 2>/dev/null | grep versionstring: | awk '{print \$3}'`;
     chomp($version);
     my $users = `/usr/local/sbin/occ user:list 2>/dev/null | wc -l`;
     chomp($users);


### PR DESCRIPTION
It should be interesting to look after versionstring rather than version 

short strory

```
  - version: 23.0.2.1
  - versionstring: 23.0.2
```

long story

```
[root@ns7loc8 ~]# /usr/local/sbin/occ status 
  - installed: true
  - version: 23.0.2.1
  - versionstring: 23.0.2
  - edition: 
  - maintenance: false
  - needsDbUpgrade: false
  - productname: Nextcloud
  - extendedSupport: false
```

