### PR TITLE
spec: update to NC 27.0.1

### DIFF
--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -6,7 +6,7 @@ License: GPL
 Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.tar.gz
 
-%define nc_version 26.0.2
+%define nc_version 27.0.1
 Source2: https://download.nextcloud.com/server/releases/nextcloud-%{nc_version}.tar.bz2
 
 BuildArch: noarch


### PR DESCRIPTION
Try to update to NextCloud 27.0.1

Requirements should be satisfied: https://docs.nextcloud.com/server/27/admin_manual/installation/system_requirements.html

Also, NC 27 could be the last Nextcloud version for NS7: https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule#currently-maintained-versions

NethServer/dev#6757