### PR TITLE
Update Nextcloud to version 27.1.11 and disable web upgrade

### DIFF
--- a/nethserver-nextcloud.spec
+++ b/nethserver-nextcloud.spec
@@ -6,7 +6,7 @@ License: GPL
 Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.tar.gz
 
-%define nc_version 27.1.7
+%define nc_version 27.1.11
 Source2: https://download.nextcloud.com/server/releases/nextcloud-%{nc_version}.tar.bz2
 
 BuildArch: noarch

--- a/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
+++ b/root/etc/e-smith/events/actions/nethserver-nextcloud-occ-conf
@@ -76,6 +76,7 @@ OCC "config:system:set mail_domain --value=".$cdb->get_value('DomainName');
 OCC "config:system:set mail_smtphost --value=localhost";
 OCC "config:system:set mail_smtpport --value=25";
 OCC "config:system:set updatechecker --type bool --value false";
+OCC "config:system:set upgrade.disable-web --type bool --value true";
 OCC "config:system:set check_for_working_wellknown_setup --type bool --value false";
 OCC "background:cron";
 OCC "db:convert-filecache-bigint -n";


### PR DESCRIPTION
This pull request updates Nextcloud to version 27.1.11 and disables the web upgrade feature. 

https://github.com/NethServer/dev/issues/6964